### PR TITLE
Add rust-version="1.65" in prse-derive Cargo.toml

### DIFF
--- a/prse-derive/Cargo.toml
+++ b/prse-derive/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../README.md"
 description = "A helper macro crate for the prse crate."
 keywords = ["string", "parsing", "format-args", "no-std"]
 categories = ["parsing"]
+rust-version = "1.65"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]


### PR DESCRIPTION
Because prse-derive uses let ... else statements which were only stabilized in (the relatively recent) rust 1.65.0, I believe it will make for better error messages for people on older rust versions to specify the Minimal Supported Rust Version (aka. MSRV).