### PR TITLE
expand_unit: Always use string literals

### DIFF
--- a/prse-derive/src/expand_derive.rs
+++ b/prse-derive/src/expand_derive.rs
@@ -4,7 +4,6 @@ use syn::{GenericParam, Generics, ImplGenerics, WhereClause, WherePredicate};
 
 use crate::derive::{Derive, Fields};
 use crate::instructions::Instructions;
-use crate::invocation::string_to_tokens;
 
 impl Derive {
     pub fn into_token_stream(self) -> TokenStream {
@@ -131,7 +130,7 @@ fn expand_tuple(
 }
 
 fn expand_unit(s: String, to_return: TokenStream, error: Option<TokenStream>) -> TokenStream {
-    let l_string = string_to_tokens(&s);
+    let l_string = s.to_token_stream();
     let error = error.unwrap_or_else(|| {
         if cfg!(feature = "alloc") {
             quote! {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,32 @@
+mod common {
+    use prse::{parse, Parse};
+
+    #[test]
+    fn empty_literal() {
+        let input = "";
+        parse!(input, "");
+        let input = "Test";
+        parse!(input, "Test")
+    }
+
+    #[derive(Parse, Eq, PartialEq, Debug)]
+    enum SimpleAlphabet {
+        #[prse = "A"]
+        A,
+        #[prse = "B"]
+        B,
+    }
+
+    #[derive(Parse, Eq, PartialEq, Debug)]
+    #[prse = "{:-:2}"]
+    struct Alphabets([SimpleAlphabet; 2]);
+
+    #[test]
+    fn parse_single_chars() {
+        assert_eq!(SimpleAlphabet::A, parse!("A", "{}"));
+        assert_eq!(
+            Alphabets([SimpleAlphabet::A, SimpleAlphabet::B]),
+            parse!("A-B", "{}")
+        )
+    }
+}

--- a/tests/test-alloc/lib.rs
+++ b/tests/test-alloc/lib.rs
@@ -92,11 +92,5 @@ mod tests {
         assert_eq!(var, "test:")
     }
 
-    #[test]
-    fn empty_literal() {
-        let input = "";
-        parse!(input, "");
-        let input = "Test";
-        parse!(input, "Test")
-    }
+    include!("../common.rs");
 }

--- a/tests/test-no-std/lib.rs
+++ b/tests/test-no-std/lib.rs
@@ -92,11 +92,5 @@ mod tests {
         assert_eq!(num, 7)
     }
 
-    #[test]
-    fn empty_literal() {
-        let input = "";
-        parse!(input, "");
-        let input = "Test";
-        parse!(input, "Test")
-    }
+    include!("../common.rs");
 }

--- a/tests/test-std/lib.rs
+++ b/tests/test-std/lib.rs
@@ -98,14 +98,6 @@ mod tests {
         assert_eq!(num, 7)
     }
 
-    #[test]
-    fn empty_literal() {
-        let input = "";
-        parse!(input, "");
-        let input = "Test";
-        parse!(input, "Test")
-    }
-
     #[derive(Debug, Parse)]
     struct Position {
         x: i32,
@@ -173,4 +165,6 @@ mod tests {
             }
         )
     }
+
+    include!("../common.rs");
 }


### PR DESCRIPTION
`string_to_tokens` will use a character literal if the string is a single character. This is fine for str's Pattern APIs, but in this case the string is being used as a pattern in a match arm, which must be a string literal.

Fixes #23