### PR TITLE
Add lifetime bounds to derived struct and enums

### DIFF
--- a/prse-derive/src/expand_derive.rs
+++ b/prse-derive/src/expand_derive.rs
@@ -1,6 +1,8 @@
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::ToTokens;
-use syn::{GenericParam, Generics, ImplGenerics, WhereClause, WherePredicate};
+use syn::{
+    GenericParam, Generics, ImplGenerics, Lifetime, LifetimeParam, WhereClause, WherePredicate,
+};
 
 use crate::derive::{Derive, Fields};
 use crate::instructions::Instructions;
@@ -175,7 +177,12 @@ fn split_for_impl(
 ) -> (ImplGenerics, TokenStream, Option<&WhereClause>) {
     let ty_generics = generics.split_for_impl().1.to_token_stream();
 
-    generics.params.push(parse_quote!('__prse_a));
+    generics.params.push(GenericParam::Lifetime(LifetimeParam {
+        attrs: vec![],
+        lifetime: Lifetime::new("'__prse_a", Span::call_site()),
+        colon_token: None,
+        bounds: generics.lifetimes().map(|l| l.lifetime.clone()).collect(),
+    }));
 
     let type_predicates: Vec<WherePredicate> = generics
         .params

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -32,6 +32,7 @@ mod common {
 
     #[derive(Parse, Debug, PartialEq, Eq)]
     enum Capture<'c> {
+        #[prse = "{}"]
         Single(&'c str),
     }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -29,4 +29,27 @@ mod common {
             parse!("A-B", "{}")
         )
     }
+
+    #[derive(Parse, Debug, PartialEq, Eq)]
+    enum Capture<'c> {
+        Single(&'c str),
+    }
+
+    #[derive(Parse, Debug, Eq, PartialEq)]
+    #[prse = "{b} {c:-:2}"]
+    struct Lifetimes<'a, 'b> {
+        b: Capture<'a>,
+        c: [&'b str; 2],
+    }
+
+    #[test]
+    fn parse_lifetime_derive() {
+        assert_eq!(
+            Lifetimes {
+                b: Capture::Single("yummy"),
+                c: ["gummy", "bear"]
+            },
+            parse!("yummy gummy-bear", "{}")
+        );
+    }
 }


### PR DESCRIPTION
This will allow in future to parse iterators in structs and enums