### PR TITLE
Allow multiple prse attributes on a single enum variant

### DIFF
--- a/prse-derive/src/lib.rs
+++ b/prse-derive/src/lib.rs
@@ -167,21 +167,24 @@ pub fn try_parse(input: TokenStream) -> TokenStream {
 /// #[derive(Debug, Parse, Eq, PartialEq)]
 /// enum Position {
 ///     #[prse = "({x}, {y})"]
-///     Position { x: i32, y: i32 },
+///     Pos { x: i32, y: i32 },
 ///     #[prse = "({})"]
-///     SinglePositon(i32),
+///     SinglePos(i32),
 ///     #[prse = "()"]
-///     NoPosition,
+///     #[prse = ""]
+///     NoPos,
 /// }
 ///
 /// // the first prse attribute to match is used.
 /// let pos0: Position = parse!("This is a position: (1, 2)", "This is a position: {}");
 /// let pos1: Position = parse!("This is a position: (3)", "This is a position: {}");
 /// let pos2: Position = parse!("This is a position: ()", "This is a position: {}");
+/// let pos3: Position = parse!("This is a position: ", "This is a position: {}");
 ///
-/// assert_eq!(pos0, Position::Position { x: 1, y: 2 });
-/// assert_eq!(pos1, Position::SinglePositon(3));
-/// assert_eq!(pos2, Position::NoPosition);
+/// assert_eq!(pos0, Position::Pos { x: 1, y: 2 });
+/// assert_eq!(pos1, Position::SinglePos(3));
+/// assert_eq!(pos2, Position::NoPos);
+/// assert_eq!(pos3, Position::NoPos);
 ///```
 /// If no prse attributes are found, it will use your [`FromStr`](core::str::FromStr) implementation.
 /// ```ignore

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -61,4 +61,19 @@ mod common {
             parse!(" false , 2 , 3 , 5.0 ", "{},{},{},{}")
         )
     }
+
+    #[derive(Parse, Debug, Eq, PartialEq)]
+    enum Char {
+        #[prse = "a:{}"]
+        #[prse = "A:{}"]
+        A(u32),
+        #[prse = "b"]
+        B,
+    }
+
+    #[test]
+    fn parse_multi_enum() {
+        let l = "a:4 A:3 b";
+        assert_eq!((Char::A(4), Char::A(3), Char::B), parse!(l, "{} {} {}"));
+    }
 }

--- a/tests/test-std/ui/derive.stderr
+++ b/tests/test-std/ui/derive.stderr
@@ -65,10 +65,12 @@ error: Unexpected prse attribute.
    |          ^^^^^^^^^^^^^^^^
 
 error: The derive macro must either have an attribute on each field or none at all.
-  --> ui/derive.rs:71:6
+  --> ui/derive.rs:70:10
    |
-71 | enum L {
-   |      ^
+70 | #[derive(Parse)]
+   |          ^^^^^
+   |
+   = note: this error originates in the derive macro `Parse` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: Unexpected prse attribute.
   --> ui/derive.rs:83:10


### PR DESCRIPTION
Allows
```rust
#[derive(Parse, Debug)]
enum Char {
    #[prse = "a"]
    #[prse = "A"]
    A,
    #[prse = "b"]
    B,
}
```