### PR TITLE
Add context to ParseErrors

### DIFF
--- a/prse-derive/src/expand_derive.rs
+++ b/prse-derive/src/expand_derive.rs
@@ -72,7 +72,10 @@ fn expand_field(
 
     instructions.gen_return_idents(&mut return_idents, &mut func_idents, &mut renames);
 
-    let mut body = quote!(let mut __prse_parse;);
+    let mut body = quote! {
+        let mut __prse_parse: &str;
+        let mut __prse_remaining = __prse_input;
+    };
 
     instructions.gen_body(&mut body);
 
@@ -82,7 +85,7 @@ fn expand_field(
 
     quote! {
         {
-            use ::prse::{ExtParseStr, Parse};
+            use ::prse::Parse;
 
             #function
 
@@ -109,7 +112,10 @@ fn expand_tuple(
 
     instructions.gen_return_idents(&mut return_idents, &mut func_idents, &mut _renames);
 
-    let mut body = quote!(let mut __prse_parse;);
+    let mut body = quote! {
+        let mut __prse_parse: &str;
+        let mut __prse_remaining = __prse_input;
+    };
 
     instructions.gen_body(&mut body);
 
@@ -117,7 +123,7 @@ fn expand_tuple(
 
     quote! {
         {
-            use ::prse::{ExtParseStr, Parse};
+            use ::prse::Parse;
 
             #function
 

--- a/prse-derive/src/instructions.rs
+++ b/prse-derive/src/instructions.rs
@@ -200,7 +200,7 @@ impl Instructions {
 
         quote! {
             fn #func_name <'a, #(#generics: Parse<'a>),* >(
-                mut __prse_input: &'a str,
+                __prse_input: &'a str,
             ) -> ::core::result::Result<( #(#return_types),* ), ::prse::ParseError> {
                 #body
             }
@@ -223,12 +223,12 @@ impl Instructions {
 
                     result.append_all(if cfg!(feature = "alloc") {
                         quote! {
-                            (__prse_parse, __prse_input) = __prse_input.split_once(#l_string)
-                                .ok_or_else(|| ::prse::ParseError::Literal {expected: (#l_string).into(), found: __prse_input.into()})?;
+                            (__prse_parse, __prse_remaining) = __prse_remaining.split_once(#l_string)
+                                .ok_or_else(|| ::prse::ParseError::Literal {expected: (#l_string).into(), found: __prse_remaining.into()})?;
                         }
                     } else {
                         quote! {
-                            (__prse_parse, __prse_input) = __prse_input.split_once(#l_string)
+                            (__prse_parse, __prse_remaining) = __prse_remaining.split_once(#l_string)
                                 .ok_or_else(|| ::prse::ParseError::Literal)?;
                         }
                     });
@@ -240,7 +240,7 @@ impl Instructions {
                 }
                 Instruction::Parse(_) => {
                     store_token = Some(quote! {
-                        let #var = __prse_parse.lending_parse()?;
+                        let #var = ::prse::__private::try_parse_context(__prse_parse, __prse_input)?;
                     });
                 }
                 Instruction::VecParse(..) => {
@@ -280,17 +280,17 @@ impl Instructions {
         }
         result.append_all(store_token.map_or_else(|| if cfg!(feature = "alloc") {
             quote! {
-                if !__prse_input.is_empty() {
-                    return Err(::prse::ParseError::Literal {expected: "".into(), found: __prse_input.into()})
+                if !__prse_remaining.is_empty() {
+                    return Err(::prse::ParseError::Literal {expected: "".into(), found: __prse_remaining.into()})
                 }
             }
         } else {
             quote! {
-                if !__prse_input.is_empty() {
+                if !__prse_remaining.is_empty() {
                     return Err(::prse::ParseError::Literal)
                 }
             }
-        }, |t| quote! { __prse_parse = __prse_input; #t }));
+        }, |t| quote! { __prse_parse = __prse_remaining; #t }));
 
         let return_idents = self.0.iter().enumerate().filter_map(|(idx, i)| {
             i.get_var()?;

--- a/prse-derive/src/instructions.rs
+++ b/prse-derive/src/instructions.rs
@@ -262,14 +262,14 @@ impl Instructions {
                         let mut __prse_iter = #iter;
                         let #var = [ #(
                             __prse_iter.next()
-                            .ok_or_else(|| ::prse::ParseError::Multi {
+                            .ok_or_else(|| ::prse::ParseError::Array {
                                 expected: #count,
                                 found: #idx,
                             })??
                         ),* ];
                         let __prse_count_left = __prse_iter.count();
                         if __prse_count_left != 0 {
-                            return Err(::prse::ParseError::Multi {
+                            return Err(::prse::ParseError::Array {
                                 expected: #count,
                                 found: #count + __prse_count_left as u8,
                             });

--- a/tests/test-alloc/lib.rs
+++ b/tests/test-alloc/lib.rs
@@ -40,7 +40,7 @@ mod tests {
         let case: Result<[&str; 2], _> = try_parse!(l, "I love the following: {:, :2}.");
         assert_eq!(
             case,
-            Err(ParseError::Multi {
+            Err(ParseError::Array {
                 expected: 2,
                 found: 3
             })
@@ -48,7 +48,7 @@ mod tests {
         let case: Result<[&str; 4], _> = try_parse!(l, "I love the following: {:, :4}.");
         assert_eq!(
             case,
-            Err(ParseError::Multi {
+            Err(ParseError::Array {
                 expected: 4,
                 found: 3
             })

--- a/tests/test-no-std/lib.rs
+++ b/tests/test-no-std/lib.rs
@@ -35,7 +35,7 @@ mod tests {
         let case: Result<[&str; 2], _> = try_parse!(l, "I love the following: {:, :2}.");
         assert_eq!(
             case,
-            Err(ParseError::Multi {
+            Err(ParseError::Array {
                 expected: 2,
                 found: 3
             })
@@ -43,7 +43,7 @@ mod tests {
         let case: Result<[&str; 4], _> = try_parse!(l, "I love the following: {:, :4}.");
         assert_eq!(
             case,
-            Err(ParseError::Multi {
+            Err(ParseError::Array {
                 expected: 4,
                 found: 3
             })

--- a/tests/test-std/lib.rs
+++ b/tests/test-std/lib.rs
@@ -73,7 +73,7 @@ mod tests {
         let case: Result<[&str; 2], _> = try_parse!(l, "I love the following: {:, :2}.");
         assert_eq!(
             case,
-            Err(ParseError::Multi {
+            Err(ParseError::Array {
                 expected: 2,
                 found: 3
             })
@@ -81,7 +81,7 @@ mod tests {
         let case: Result<[&str; 4], _> = try_parse!(l, "I love the following: {:, :4}.");
         assert_eq!(
             case,
-            Err(ParseError::Multi {
+            Err(ParseError::Array {
                 expected: 4,
                 found: 3
             })


### PR DESCRIPTION
```
Unable to parse input:
        unable to parse "yum: 2-1a" when parsing "a: 4 yum: 2-1a (3)":
        unable to parse multi-item "1a" when parsing "2-1a":
        unable to parse as an integer
```